### PR TITLE
feat(web): add authentication to access chat logs

### DIFF
--- a/web/pages/chat.php
+++ b/web/pages/chat.php
@@ -36,60 +36,248 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 For support and installation notes visit http://www.hlxcommunity.com
 */
 
-	if ( !defined('IN_HLSTATS') )
+class Auth
+{
+	var $ok = false;
+	var $error = false;
+
+	var $username, $password, $savepass;
+	var $sessionStart, $session;
+
+	var $userdata = array();
+
+	function Auth()
 	{
-		die('Do not access this file directly.');
+		//@session_start();
+
+		if (valid_request($_POST['authusername'], 0))
+		{
+			$this->username = valid_request($_POST['authusername'], 0);
+			$this->password = valid_request($_POST['authpassword'], 0);
+			$this->savepass = valid_request($_POST['authsavepass'], 0);
+			$this->sessionStart = 0;
+
+			# clear POST vars so as not to confuse the receiving page
+			$_POST = array();
+
+			$this->session = false;
+
+			if($this->checkPass()==true)
+			{
+				// if we have success, save it in this users SESSION
+				$_SESSION['username']=$this->username;
+				$_SESSION['password']=$this->password;
+				$_SESSION['authsessionStart']=time();
+				$_SESSION['acclevel'] = $this->userdata['acclevel'];
+			}
+		}
+		elseif (isset($_SESSION['loggedin']))
+		{
+			$this->username = $_SESSION['username'];
+			$this->password = $_SESSION['password'];
+			$this->savepass = 0;
+			$this->sessionStart = $_SESSION['authsessionStart'];
+			$this->ok = true;
+			$this->error = false;
+			$this->session = true;
+
+			if(!$this->checkPass())
+			{
+				unset($_SESSION['loggedin']);
+			}
+		}
+		else
+		{
+			$this->ok = false;
+			$this->error = false;
+
+			$this->session = false;
+
+			$this->printAuth();
+		}
 	}
-// Global Server Chat History
-	$showserver=0;
-	if (isset($_GET['server_id']))
+
+	function checkPass()
 	{
-		$showserver = valid_request(strval($_GET['server_id']), true);
-	}
-	if ($showserver == 0)
-	{
-		$whereclause = "hlstats_Servers.game='$game'";
-	}
-	else
-	{
-		$whereclause = "hlstats_Servers.game='$game' AND hlstats_Events_Chat.serverId=$showserver";
-	}
-	$db->query
-	("
-		SELECT
-			hlstats_Games.name
-		FROM
-			hlstats_Games
-		WHERE
-			hlstats_Games.code = '$game'
-	");
-	if ($db->num_rows() < 1) error("No such game '$game'.");
-	list($gamename) = $db->fetch_row();
-	$db->free_result();
-	pageHeader
-	(
-		array ($gamename, 'Server Chat Statistics'),
-		array ($gamename=>"%s?game=$game", 'Server Chat Statistics'=>'')
-	);
-	flush();
-	$servername = "(All Servers)";
-	
-	if ($showserver != 0)
-	{
-		$result=$db->fetch_array
-		(
-			$db->query
-			("
+		global $db;
+
+		$db->query("
 				SELECT
-					hlstats_Servers.name
+					*
 				FROM
-					hlstats_Servers
+					hlstats_Users
 				WHERE
-					hlstats_Servers.serverId = ".$db->escape($showserver)."
-			")
-		);
-		$servername = "(" . $result['name'] . ")";
+					username='$this->username'
+				LIMIT 1
+			");
+
+		if ($db->num_rows() == 1)
+		{
+			// The username is OK
+
+			$this->userdata = $db->fetch_array();
+			$db->free_result();
+
+			if (md5($this->password) == $this->userdata["password"])
+			{
+				// The username and the password are OK
+
+				$this->ok = true;
+				$this->error = false;
+				$_SESSION['loggedin']=1;
+				if ($this->sessionStart > (time() - 3600))
+				{
+					// Valid session, update session time & display the page
+					$this->doCookies();
+					return true;
+				}
+				elseif ($this->sessionStart)
+				{
+					// A session exists but has expired
+					if ($this->savepass)
+					{
+						// They selected 'Save my password' so we just
+						// generate a new session and show the page.
+						$this->doCookies();
+						return true;
+					}
+					else
+					{
+						$this->ok = false;
+						$this->error = 'Your session has expired. Please try again.';
+						$this->password = '';
+
+						$this->printAuth();
+						return false;
+					}
+				}
+				elseif (!$this->session)
+				{
+					// No session and no cookies, but the user/pass was
+					// POSTed, so we generate cookies.
+					$this->doCookies();
+					return true;
+				}
+				else
+				{
+					// No session, user/pass from a cookie, so we force auth
+					$this->printAuth();
+					return false;
+				}
+			}
+			else
+			{
+				// The username is OK but the password is wrong
+
+				$this->ok = false;
+				if ($this->session)
+				{
+					// Cookie without 'Save my password' - not an error
+					$this->error = false;
+				}
+				else
+				{
+					$this->error = 'The password you supplied is incorrect.';
+				}
+				$this->password = '';
+				$this->printAuth();
+			}
+		}
+		else
+		{
+			// The username is wrong
+			$this->ok = false;
+			$this->error = 'The username you supplied is not valid.';
+			$this->printAuth();
+		}
 	}
+
+	function doCookies()
+	{
+		return;
+		setcookie('authusername', $this->username, time() + 31536000, '', '', 0);
+
+		if ($this->savepass)
+		{
+			setcookie('authpassword', $this->password, time() + 31536000, '', '', 0);
+		}
+		else
+		{
+			setcookie('authpassword', $this->password, 0, '', '', 0);
+		}
+		setcookie('authsavepass', $this->savepass, time() + 31536000, '', '', 0);
+		setcookie('authsessionStart', time(), 0, '', '', 0);
+	}
+
+	function printAuth()
+	{
+		global $g_options;
+
+		include (PAGE_PATH . '/adminauth.php');
+	}
+}
+
+$auth = new Auth;
+if ($auth->ok === false || $auth->userdata['acclevel'] < 80)
+{
+	return;
+}
+
+if ( !defined('IN_HLSTATS') )
+{
+	die('Do not access this file directly.');
+}
+// Global Server Chat History
+$showserver=0;
+if (isset($_GET['server_id']))
+{
+	$showserver = valid_request(strval($_GET['server_id']), true);
+}
+if ($showserver == 0)
+{
+	$whereclause = "hlstats_Servers.game='$game'";
+}
+else
+{
+	$whereclause = "hlstats_Servers.game='$game' AND hlstats_Events_Chat.serverId=$showserver";
+}
+$db->query
+("
+	SELECT
+		hlstats_Games.name
+	FROM
+		hlstats_Games
+	WHERE
+		hlstats_Games.code = '$game'
+");
+if ($db->num_rows() < 1) error("No such game '$game'.");
+list($gamename) = $db->fetch_row();
+$db->free_result();
+pageHeader
+(
+	array ($gamename, 'Server Chat Statistics'),
+	array ($gamename=>"%s?game=$game", 'Server Chat Statistics'=>'')
+);
+flush();
+$servername = "(All Servers)";
+
+if ($showserver != 0)
+{
+	$result=$db->fetch_array
+	(
+		$db->query
+		("
+			SELECT
+				hlstats_Servers.name
+			FROM
+				hlstats_Servers
+			WHERE
+				hlstats_Servers.serverId = ".$db->escape($showserver)."
+		")
+	);
+	$servername = "(" . $result['name'] . ")";
+}
+
 ?>
 
 <div class="block">

--- a/web/pages/chathistory.php
+++ b/web/pages/chathistory.php
@@ -35,11 +35,198 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 For support and installation notes visit http://www.hlxcommunity.com
 */
+class Auth
+{
+	var $ok = false;
+	var $error = false;
 
-	if ( !defined('IN_HLSTATS') )
+	var $username, $password, $savepass;
+	var $sessionStart, $session;
+
+	var $userdata = array();
+
+	function Auth()
 	{
-		die('Do not access this file directly.');
+		//@session_start();
+
+		if (valid_request($_POST['authusername'], 0))
+		{
+			$this->username = valid_request($_POST['authusername'], 0);
+			$this->password = valid_request($_POST['authpassword'], 0);
+			$this->savepass = valid_request($_POST['authsavepass'], 0);
+			$this->sessionStart = 0;
+
+			# clear POST vars so as not to confuse the receiving page
+			$_POST = array();
+
+			$this->session = false;
+
+			if($this->checkPass()==true)
+			{
+				// if we have success, save it in this users SESSION
+				$_SESSION['username']=$this->username;
+				$_SESSION['password']=$this->password;
+				$_SESSION['authsessionStart']=time();
+				$_SESSION['acclevel'] = $this->userdata['acclevel'];
+			}
+		}
+		elseif (isset($_SESSION['loggedin']))
+		{
+			$this->username = $_SESSION['username'];
+			$this->password = $_SESSION['password'];
+			$this->savepass = 0;
+			$this->sessionStart = $_SESSION['authsessionStart'];
+			$this->ok = true;
+			$this->error = false;
+			$this->session = true;
+
+			if(!$this->checkPass())
+			{
+				unset($_SESSION['loggedin']);
+			}
+		}
+		else
+		{
+			$this->ok = false;
+			$this->error = false;
+
+			$this->session = false;
+
+			$this->printAuth();
+		}
 	}
+
+	function checkPass()
+	{
+		global $db;
+
+		$db->query("
+				SELECT
+					*
+				FROM
+					hlstats_Users
+				WHERE
+					username='$this->username'
+				LIMIT 1
+			");
+
+		if ($db->num_rows() == 1)
+		{
+			// The username is OK
+
+			$this->userdata = $db->fetch_array();
+			$db->free_result();
+
+			if (md5($this->password) == $this->userdata["password"])
+			{
+				// The username and the password are OK
+
+				$this->ok = true;
+				$this->error = false;
+				$_SESSION['loggedin']=1;
+				if ($this->sessionStart > (time() - 3600))
+				{
+					// Valid session, update session time & display the page
+					$this->doCookies();
+					return true;
+				}
+				elseif ($this->sessionStart)
+				{
+					// A session exists but has expired
+					if ($this->savepass)
+					{
+						// They selected 'Save my password' so we just
+						// generate a new session and show the page.
+						$this->doCookies();
+						return true;
+					}
+					else
+					{
+						$this->ok = false;
+						$this->error = 'Your session has expired. Please try again.';
+						$this->password = '';
+
+						$this->printAuth();
+						return false;
+					}
+				}
+				elseif (!$this->session)
+				{
+					// No session and no cookies, but the user/pass was
+					// POSTed, so we generate cookies.
+					$this->doCookies();
+					return true;
+				}
+				else
+				{
+					// No session, user/pass from a cookie, so we force auth
+					$this->printAuth();
+					return false;
+				}
+			}
+			else
+			{
+				// The username is OK but the password is wrong
+
+				$this->ok = false;
+				if ($this->session)
+				{
+					// Cookie without 'Save my password' - not an error
+					$this->error = false;
+				}
+				else
+				{
+					$this->error = 'The password you supplied is incorrect.';
+				}
+				$this->password = '';
+				$this->printAuth();
+			}
+		}
+		else
+		{
+			// The username is wrong
+			$this->ok = false;
+			$this->error = 'The username you supplied is not valid.';
+			$this->printAuth();
+		}
+	}
+
+	function doCookies()
+	{
+		return;
+		setcookie('authusername', $this->username, time() + 31536000, '', '', 0);
+
+		if ($this->savepass)
+		{
+			setcookie('authpassword', $this->password, time() + 31536000, '', '', 0);
+		}
+		else
+		{
+			setcookie('authpassword', $this->password, 0, '', '', 0);
+		}
+		setcookie('authsavepass', $this->savepass, time() + 31536000, '', '', 0);
+		setcookie('authsessionStart', time(), 0, '', '', 0);
+	}
+
+	function printAuth()
+	{
+		global $g_options;
+
+		include (PAGE_PATH . '/adminauth.php');
+	}
+}
+
+$auth = new Auth;
+if ($auth->ok === false || $auth->userdata['acclevel'] < 80)
+{
+	return;
+}
+
+if ( !defined('IN_HLSTATS') )
+{
+	die('Do not access this file directly.');
+}
+
 // Player Chat History
 	$player = valid_request(intval($_GET['player']), 1)
 		or error('No player ID specified.');


### PR DESCRIPTION
Players shouldnt be able to access this page and it creates a database overload if someone starts to spam this page with a script